### PR TITLE
Update prodId and package.js

### DIFF
--- a/bin/csv2ical.js
+++ b/bin/csv2ical.js
@@ -33,10 +33,12 @@ const stream = fs.createReadStream(argv.i);
 // const log = new winston.Logger();
 const cal = ical.default();
 
-// ToDo reading ProdID from args or config file
+// "This property specifies the identifier for the product that created the 
+// iCalendar object." "The property MUST be specified once in an iCalendar
+// object." // https://datatracker.ietf.org/doc/html/rfc5545#section-3.7.3
 cal.prodId({
-  company: 'My Company',
-  product: 'My Product',
+  company: 'kakurady',
+  product: 'csv2ical',
   language: 'EN',
 });
 cal.name('My Calendar');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csv2ical",
-  "description": "Quick and dirty CSV to iCal convertor",
-  "author": "Amine Benseddik <amine.benseddik@gmail.com>",
+  "description": "Quick and dirty CSV to iCal converter",
+  "author": "Kakurady <kakurady@gmail.com>",
   "homepage": "http://c2fo.github.com/fast-csv/index.html",
   "license": "MIT",
   "version": "0.1.2",
@@ -14,13 +14,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:amine7536/csv2ical.js.git"
+    "url": "git@github.com:Kakurady/csv2ical.js.git"
   },
   "keywords": [
     "csv",
     "parser",
+    "converter",
     "ical",
-    "calendar"
+    "calendar",
+    "icalendar",
+    "rfc2445",
+    "rfc5545"
   ],
   "devDependencies": {
     "eslint": "^8.46.0",

--- a/src/csv2ical.js
+++ b/src/csv2ical.js
@@ -33,10 +33,12 @@ const stream = fs.createReadStream(argv.i);
 // const log = new winston.Logger();
 const cal = ical.default();
 
-// ToDo reading ProdID from args or config file
+// "This property specifies the identifier for the product that created the 
+// iCalendar object." "The property MUST be specified once in an iCalendar
+// object." // https://datatracker.ietf.org/doc/html/rfc5545#section-3.7.3
 cal.prodId({
-  company: 'My Company',
-  product: 'My Product',
+  company: 'kakurady',
+  product: 'csv2ical',
   language: 'EN',
 });
 cal.name('My Calendar');


### PR DESCRIPTION
Changed repository URL to that of the work, and attribution fields to the author of the fork.

ProdId is used to identify the author and product (that is, csv2ical), and there is no point to read it from configuration.

Added keywords for iCalendar, RFC 2445 and 5545.